### PR TITLE
Add d3 to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,8 @@
     "tests"
   ],
   "dependencies": {
-    "gulp": "^3.9.1"
+    "gulp": "^3.9.1",
+    "d3": "^4.7.3"
   },
   "devDependencies": {
     "foundation": "^5.5.3"


### PR DESCRIPTION
Resolves the known issue mentioned by JordanCollins where d3 doesn't install along with the other bower components. Super simple change, but for anybody unfamiliar with how bower works, this could be really frustrating to figure out.